### PR TITLE
Fix: "Change AbstractCollectionRepository interface name"

### DIFF
--- a/src/main/java/com/andersentask/bookshop/book/repositories/BookRepository.java
+++ b/src/main/java/com/andersentask/bookshop/book/repositories/BookRepository.java
@@ -1,13 +1,13 @@
 package com.andersentask.bookshop.book.repositories;
 
 import com.andersentask.bookshop.book.entities.Book;
-import com.andersentask.bookshop.common.AbstractCollectionRepository;
+import com.andersentask.bookshop.common.CollectionRepository;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-public class BookRepository implements AbstractCollectionRepository<Book, Long> {
+public class BookRepository implements CollectionRepository<Book, Long> {
     private final List<Book> books;
     private Long id;
 

--- a/src/main/java/com/andersentask/bookshop/common/CollectionRepository.java
+++ b/src/main/java/com/andersentask/bookshop/common/CollectionRepository.java
@@ -3,7 +3,7 @@ package com.andersentask.bookshop.common;
 import java.util.List;
 import java.util.Optional;
 
-public interface AbstractCollectionRepository<T, ID> {
+public interface CollectionRepository<T, ID> {
     T save(T obj);
 
     void delete(ID id);

--- a/src/main/java/com/andersentask/bookshop/order/repositories/OrderRepository.java
+++ b/src/main/java/com/andersentask/bookshop/order/repositories/OrderRepository.java
@@ -1,6 +1,6 @@
 package com.andersentask.bookshop.order.repositories;
 
-import com.andersentask.bookshop.common.AbstractCollectionRepository;
+import com.andersentask.bookshop.common.CollectionRepository;
 import com.andersentask.bookshop.order.entities.Order;
 import com.andersentask.bookshop.order.enums.OrderStatus;
 
@@ -9,7 +9,7 @@ import java.util.List;
 import java.util.Optional;
 
 
-public class OrderRepository implements AbstractCollectionRepository<Order, Long> {
+public class OrderRepository implements CollectionRepository<Order, Long> {
     private final List<Order> orders;
     private Long id;
 

--- a/src/main/java/com/andersentask/bookshop/request/repository/RequestRepository.java
+++ b/src/main/java/com/andersentask/bookshop/request/repository/RequestRepository.java
@@ -1,13 +1,13 @@
 package com.andersentask.bookshop.request.repository;
 
-import com.andersentask.bookshop.common.AbstractCollectionRepository;
+import com.andersentask.bookshop.common.CollectionRepository;
 import com.andersentask.bookshop.request.entities.Request;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-public class RequestRepository implements AbstractCollectionRepository<Request, Long> {
+public class RequestRepository implements CollectionRepository<Request, Long> {
 
     private final List<Request> requests;
 

--- a/src/main/java/com/andersentask/bookshop/user/repository/UserRepository.java
+++ b/src/main/java/com/andersentask/bookshop/user/repository/UserRepository.java
@@ -1,13 +1,13 @@
 package com.andersentask.bookshop.user.repository;
 
-import com.andersentask.bookshop.common.AbstractCollectionRepository;
+import com.andersentask.bookshop.common.CollectionRepository;
 import com.andersentask.bookshop.user.entities.User;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-public class UserRepository implements AbstractCollectionRepository<User, Long> {
+public class UserRepository implements CollectionRepository<User, Long> {
 
     private final List<User> users;
 


### PR DESCRIPTION
Change ```AbstractCollectionRepository``` interface name to ```CollectionRepository``` to remove inconvenience